### PR TITLE
Increase cool down limit on add command

### DIFF
--- a/_scripts/discord/cmd/add.js
+++ b/_scripts/discord/cmd/add.js
@@ -5,7 +5,7 @@ module.exports = {
   aliases: ['join', 'signup', 'su', 'Add', 'ADD'],
   guildOnly: false,
   usage: '',
-  cooldown: 2,
+  cooldown: 200,
 
   execute(message, args) {
     const Discord = require('discord.js');


### PR DESCRIPTION
Increasing the cooldown limit on the add command to allow the bot time to generate the address OTS keys. 