### PR TITLE
fix broken txn masked link

### DIFF
--- a/_scripts/discord/cmd/withdraw.js
+++ b/_scripts/discord/cmd/withdraw.js
@@ -295,7 +295,7 @@ module.exports = {
             .addField('Pending Amount:', '`' + toQuanta(Number(check[0].userArray[0][0].pending) + Number(transferAmount) + fee) + ' QRL`', true)
             .addField('Approx New Balance:', '`' + toQuanta((check[0].userArray[0][0].wallet_bal - check[0].userArray[0][0].pending) - transferAmount).toFixed(9) + ' QRL`', true)
             .addField('Address Sent to:', '[' + check[0].addressArray[0] + '](' + config.bot_details.explorer_url + '/a/' + check[0].addressArray[0] + ')')
-            .addField('Transaction Hash:', '[```yaml\n' + transferFundsOut.tx.transaction_hash + '\n```](' + config.bot_details.explorer_url + '/tx/' + transferFundsOut.tx.transaction_hash + ')')
+            .addField('Transaction Hash:', '[' + transferFundsOut.tx.transaction_hash + '](' + config.bot_details.explorer_url + '/tx/' + transferFundsOut.tx.transaction_hash + ')')
             .setFooter('  .: Tipbot provided by The QRL Contributors :.');
           message.author.send({ embed })
             .catch(error => {


### PR DESCRIPTION
recommend remove superfluous code block and 'yaml' presumed to be a nested code block.

Fixes issue resulting in such:

Transaction Hash:
[```yaml
2653f06433ac2c64be8e3c306bf0da6b87612e168a8446d2930dd639a1332e32
```](https://explorer.theqrl.org/tx/2653f06433ac2c64be8e3c306bf0da6b87612e168a8446d2930dd639a1332e32)