### PR TITLE
fix example config structures

### DIFF
--- a/_config/config.json.example
+++ b/_config/config.json.example
@@ -14,7 +14,7 @@
     "num_slaves" : "10",
     "height" : "12",
     "hash_function" : "shake128",
-    "hold_address" : "Q..."
+    "hold_address" : "Q...",
     "wallet_url" : "https://wallet.theqrl.org"
   },  
   "database" : {
@@ -49,7 +49,6 @@
     "fixed_payout" : "true",
     "fixed_amount" : "1",
     "plusone_admin" : "DISCORD_ID"
-
   },  
   "backup" : {
     "location" : "/FULL/PATH/OF/THE/BACKUP/DIR",
@@ -59,6 +58,6 @@
     "nodeConfig" : "/home/$USER/.qrl/config.yml",
     "faucetLog" : "/home/$USER/qrl-tipbot/faucet.log",
     "botLogFile" : "/home/$USER/qrl-tipbot/discord_bot.log",
-    "botConfigFile" : "/home/$USER/qrl-tipbot/_config/config.json",
+    "botConfigFile" : "/home/$USER/qrl-tipbot/_config/config.json"
   }
 }


### PR DESCRIPTION
easy stuff to miss, boilerplate fix really.

"," added and removed so nobody has to hunt for them.